### PR TITLE
Fix build error with GCC 7.3 + Ubuntu Bionic + ROS Melodic

### DIFF
--- a/include/microstrain_3dmgx2_imu/3dmgx2.h
+++ b/include/microstrain_3dmgx2_imu/3dmgx2.h
@@ -91,21 +91,21 @@ namespace microstrain_3dmgx2_imu
   class IMU
   {
     //! IMU internal ticks/second
-    static const int TICKS_PER_SEC_GX2  = 19660800;
-    static const int TICKS_PER_SEC_GX3  = 62500;
+    static const int TICKS_PER_SEC_GX2 = 19660800;
+    static const int TICKS_PER_SEC_GX3 = 62500;
     //! Maximum bytes allowed to be skipped when seeking a message
-    static const int MAX_BYTES_SKIPPED  = 1000;
+    static const int MAX_BYTES_SKIPPED = 1000;
     //! Number of KF samples to sum over
-    static const unsigned int KF_NUM_SUM= 100;
+    static const unsigned int KF_NUM_SUM = 100;
     //! First KF term
-    static const double KF_K_1          = 0.00995031;
+    static constexpr double KF_K_1 = 0.00995031;
     //! Second KF term
-    static const double KF_K_2          = 0.0000497506;
+    static constexpr double KF_K_2 = 0.0000497506;
 
   public: 
 
     //! Gravity (m/sec^2)
-    static const double G               = 9.80665;    
+    static constexpr double G = 9.80665;
 
     //! Enumeration of possible IMU commands
     enum cmd {

--- a/include/microstrain_3dmgx2_imu/3dmgx2.h
+++ b/include/microstrain_3dmgx2_imu/3dmgx2.h
@@ -269,10 +269,10 @@ namespace microstrain_3dmgx2_imu
      */
     bool getDeviceIdentifierString(id_string type, char id[17]);
 
-  private:
     //! Send a command to the IMU and wait for a reply
     int transact(void *cmd, int cmd_len, void *rep, int rep_len, int timeout = 0);
 
+  private:
     //! Send a single packet frmo the IMU
     int send(void *cmd, int cmd_len);
 

--- a/src/3dmgx2.cc
+++ b/src/3dmgx2.cc
@@ -49,9 +49,9 @@
 
 // Some systems (e.g., OS X) require explicit externing of static class
 // members.
-extern const double microstrain_3dmgx2_imu::IMU::G;
-extern const double microstrain_3dmgx2_imu::IMU::KF_K_1;
-extern const double microstrain_3dmgx2_imu::IMU::KF_K_2;
+extern constexpr double microstrain_3dmgx2_imu::IMU::G;
+extern constexpr double microstrain_3dmgx2_imu::IMU::KF_K_1;
+extern constexpr double microstrain_3dmgx2_imu::IMU::KF_K_2;
 
 //! Code to swap bytes since IMU is big endian
 static inline unsigned short bswap_16(unsigned short x) {


### PR DESCRIPTION
The attached changes are required to solve this build error: 

```
/home/summit/catkin_ws/src/microstrain_3dmgx2_imu/include/microstrain_3dmgx2_imu/3dmgx2.h:101:25: error: ‘constexpr’ needed for in-class initialization of static data member ‘const double microstrain_3dmgx2_imu::IMU::KF_K_1’ of non-integral type [-fpermissive]
     static const double KF_K_1          = 0.00995031;
                         ^~~~~~
/home/summit/catkin_ws/src/microstrain_3dmgx2_imu/include/microstrain_3dmgx2_imu/3dmgx2.h:103:25: error: ‘constexpr’ needed for in-class initialization of static data member ‘const double microstrain_3dmgx2_imu::IMU::KF_K_2’ of non-integral type [-fpermissive]
     static const double KF_K_2          = 0.0000497506;
                         ^~~~~~
/home/summit/catkin_ws/src/microstrain_3dmgx2_imu/include/microstrain_3dmgx2_imu/3dmgx2.h:108:25: error: ‘constexpr’ needed for in-class initialization of static data member ‘const double microstrain_3dmgx2_imu::IMU::G’ of non-integral type [-fpermissive]
     static const double G               = 9.80665;
                         ^
```
