### PR TITLE
Fix melodic build (backwards compatible alternative to #10)

### DIFF
--- a/include/microstrain_3dmgx2_imu/3dmgx2.h
+++ b/include/microstrain_3dmgx2_imu/3dmgx2.h
@@ -90,6 +90,10 @@ namespace microstrain_3dmgx2_imu
    */
   class IMU
   {
+// from C++11, constexpr specifier is requred for double
+#if __cplusplus > 199711L
+#define const constexpr
+#endif
     //! IMU internal ticks/second
     static const int TICKS_PER_SEC_GX2  = 19660800;
     static const int TICKS_PER_SEC_GX3  = 62500;
@@ -106,6 +110,9 @@ namespace microstrain_3dmgx2_imu
 
     //! Gravity (m/sec^2)
     static const double G               = 9.80665;    
+#if __cplusplus > 199711L
+#undef const
+#endif
 
     //! Enumeration of possible IMU commands
     enum cmd {


### PR DESCRIPTION
This is an alternative to #10 suggested and supplied by @k-okada that is backwards compatible with trusty. @davefeilseifer please consider merging this or #10 and releasing, since the melodic build is broken for this package:

[![Build Status](http://build.ros.org/buildStatus/icon?job=Mbin_uB64__microstrain_3dmgx2_imu__ubuntu_bionic_amd64__binary&build=7)](http://build.ros.org/job/Mbin_uB64__microstrain_3dmgx2_imu__ubuntu_bionic_amd64__binary/7/) http://build.ros.org/job/Mbin_uB64__microstrain_3dmgx2_imu__ubuntu_bionic_amd64__binary/7/